### PR TITLE
document permissions, bump libsmu for more robust version, add udev rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,4 +38,11 @@ To get an up-to-date binary build for Windows:
  * Extract the dependency package and overwrite the included pixelpulse2.exe with the latest build downloaded from AppVeyor.
  * With a M1K attached, double-click the executable to launch Pixelpulse.
 
+To get build dependencies easily on Ubuntu/Debian derived Linux distributions:
 
+ * sudo apt-get install qtdeclarative5-dev mesa-common-dev libusb-1.0-dev build-essential pkg-config qt5-default qtbase5-dev qml-module-qtquick-controls
+
+To properly set up permissions on Linux distributions using udev:
+
+ * sudo cp ./linux/70-smu.rules /etc/udev/rules.d/
+ * sudo udevadm control --reload-rules

--- a/linux/70-smus.rules
+++ b/linux/70-smus.rules
@@ -1,2 +1,6 @@
-SUBSYSTEM=="usb", ATTR{idVendor}=="064b", ATTR{idProduct}=="784c", MODE="0666"
+SUBSYSTEM=="usb", ATTR{idVendor}=="59e3", ATTR{idProduct}=="cee1", MODE="0666"
+SUBSYSTEM=="usb", ATTR{idVendor}=="59e3", ATTR{idProduct}=="b003", MODE="0666"
+SUBSYSTEM=="usb", ATTR{idVendor}=="59e3", ATTR{idProduct}=="bbbb", MODE="0666"
+SUBSYSTEM=="usb", ATTR{idVendor}=="59e3", ATTR{idProduct}=="CEE1", MODE="0666"
 SUBSYSTEM=="usb", ATTR{idVendor}=="03eb", ATTR{idProduct}=="6124", MODE="0666"
+SUBSYSTEM=="usb", ATTR{idVendor}=="064b", ATTR{idProduct}=="784c", MODE="0666"

--- a/linux/70-smus.rules
+++ b/linux/70-smus.rules
@@ -1,0 +1,2 @@
+SUBSYSTEM=="usb", ATTR{idVendor}=="064b", ATTR{idProduct}=="784c", MODE="0666"
+SUBSYSTEM=="usb", ATTR{idVendor}=="03eb", ATTR{idProduct}=="6124", MODE="0666"


### PR DESCRIPTION
This solves segfaults on launch with inadequate permissions, documents linux build system setup, and udev rule install.