### PR TITLE
improve timing ux

### DIFF
--- a/qml/Controller.qml
+++ b/qml/Controller.qml
@@ -4,6 +4,7 @@ Item {
   property bool enabled: false
   property bool continuous: false
   property bool repeat: true
+  // TODO: should be queried from libsmu / device
   property real sampleRate: 100000
   property real sampleTime: 0.1
   readonly property int sampleCount: sampleTime * sampleRate

--- a/qml/Toolbar.qml
+++ b/qml/Toolbar.qml
@@ -8,10 +8,6 @@ ToolbarStyle {
     id: timeGroup
   }
 
-  ExclusiveGroup {
-    id: rateGroup
-  }
-
   property alias repeatedSweep: repeatedSweepItem.checked
   property alias plotsVisible: plotsVisibleItem.checked
   property alias contentVisible: contentVisibleItem.checked

--- a/qml/Toolbar.qml
+++ b/qml/Toolbar.qml
@@ -31,19 +31,6 @@ ToolbarStyle {
       }
 
       Menu {
-        title: "Sample Rate"
-        MenuItem { exclusiveGroup: rateGroup; checkable: true;
-          onTriggered: controller.sampleRate = 1000; text: '1 kHz' }
-        MenuItem { exclusiveGroup: rateGroup; checkable: true;
-          onTriggered: controller.sampleRate = 4000; text: '4 kHz' }
-        MenuItem { exclusiveGroup: rateGroup; checkable: true;
-          onTriggered: controller.sampleRate = 10000; text: '10 kHz' }
-        MenuItem { exclusiveGroup: rateGroup; checkable: true;
-          onTriggered: controller.sampleRate = 40000; text: '40 kHz' }
-        MenuItem { exclusiveGroup: rateGroup; checkable: true;
-          onTriggered: controller.sampleRate = 100000; text: '100 kHz' }
-      }
-      Menu {
         title: "Sample Time"
         MenuItem { exclusiveGroup: timeGroup; checkable: true;
           onTriggered: controller.sampleTime = 0.01; text: '10 ms' }


### PR DESCRIPTION
This is part of overhauling pixelpulse2 timing - ensuring that sample rates are determined via libsmu, removing options for adjusting sample rate, etc.

Begins to address #30.