### PR TITLE
Appveyor4

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,13 +25,16 @@ build_script:
   - qmake pixelpulse2.pro
   - sh.exe scripts/libjansson_build.sh
   - mingw32-make -j8
-  - appveyor PushArtifact debug\pixelpulse2.exe
-  - windeployqt --qmldir qml debug\pixelpulse2.exe --debug --dir distrib
-  - copy C:\libcurl\bin\*.dll distrib
-  - copy C:\mingw32\bin\libjansson-4.dll distrib
-  - 7z a -y distrib.zip distrib 
-  - appveyor PushArtifact distrib.zip
+
+after_build:
+- ps: |
+    If (!(Test-Path -Path "distrib.zip")) {
+      windeployqt --qmldir qml debug\pixelpulse2.exe --debug --dir distrib
+      cp C:\libcurl\bin\*.dll distrib
+      cp C:\mingw32\bin\libjansson-4.dll distrib
+      7z a -y distrib.zip distrib
+      appveyor PushArtifact distrib.zip
+    }
 
 cache:
- - distrib -> pixelpulse2.pro
  - distrib.zip -> pixelpulse2.pro

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-os: unstable 
+os: unstable
 
 platform:
  - x86
@@ -14,7 +14,7 @@ install:
   - 7z x -y "c:\libusb.7z" -o"C:\libusb" > nul
   - ps: (new-object System.Net.WebClient).Downloadfile("http://curl.haxx.se/gknw.net/7.40.0/dist-w32/curl-7.40.0-devel-mingw32.zip", "c:\libcurl.zip")
   - 7z x -y "c:\libcurl.zip" -o"C:\" > nul
-  - mv "c:\curl-7.40.0-devel-mingw32" "c:\libcurl" 
+  - mv "c:\curl-7.40.0-devel-mingw32" "c:\libcurl"
   - ps: (new-object System.Net.WebClient).Downloadfile("http://www.digip.org/jansson/releases/jansson-2.7.tar.gz", "c:\libjansson.tar.gz")
   - 7z x -y "c:\libjansson.tar.gz" -o"C:\libjansson.tar" > nul
   - 7z x -y "c:\libjansson.tar" -o"C:\" > nul
@@ -33,8 +33,9 @@ after_build:
       cp C:\libcurl\bin\*.dll distrib
       cp C:\mingw32\bin\libjansson-4.dll distrib
       7z a -y distrib.zip distrib
-      appveyor PushArtifact distrib.zip
     }
+    appveyor PushArtifact debug\pixelpulse2.exe
+    appveyor PushArtifact distrib.zip
 
 cache:
  - distrib.zip -> pixelpulse2.pro

--- a/pixelpulse2.pro
+++ b/pixelpulse2.pro
@@ -15,7 +15,7 @@ QMAKE_CXXFLAGS_DEBUG += -ggdb
 
 CFLAGS += -v -static -static-libgcc -static-libstdc++ -g
 
-DEFINES += GIT_VERSION='"\\\"$(shell git describe --always)\\\""'
+DEFINES += GIT_VERSION='"\\\"$(shell git describe --always --tags --abbrev)\\\""'
 DEFINES += BUILD_DATE='"\\\"$(shell date +%F)\\\""'
 
 SOURCES += main.cpp \

--- a/pixelpulse2.pro
+++ b/pixelpulse2.pro
@@ -109,3 +109,4 @@ unix:!osx {
 	QMAKE_CFLAGS_DEBUG += -rdynamic
 	QMAKE_CXXFLAGS_DEBUG += -rdynamic
 }
+ 


### PR DESCRIPTION
Only rebuild Pixelpulse2's dependency package if the make file has changed.

Use the most recent tag as a reference when generating version information.