### PR TITLE
Wait for completion

### DIFF
--- a/SMU.cpp
+++ b/SMU.cpp
@@ -128,7 +128,7 @@ void SessionItem::onDetached(Device* device){
             this->cancel();
     }
     // wait for completion
-    m_session->end();
+    m_session->wait_for_completion();
     m_session->remove_device(device);
     if ((int) m_session->m_devices.size() < m_devices.size()) {
         for (auto dev: m_devices) {


### PR DESCRIPTION
There's been more than a little bit of backpedaling here. I'm pretty sure the final answer is - from the UI thread, cancel if there're active transfers, then wait for completion, than go about tearing down the device.

My biggest fear is that this is mutually exclusive with the onFinished handler - it runs on the same thread, waits for the same condition, and mutates the same (related) state.