### PR TITLE
Destroy available

### DIFF
--- a/SMU.cpp
+++ b/SMU.cpp
@@ -136,6 +136,7 @@ void SessionItem::onDetached(Device* device){
                     m_devices.removeOne(dev);
         }
     }
+    m_session->destroy_available(device);
     devicesChanged();
 }
 


### PR DESCRIPTION
This is a fairly basic PR to be merged after testing on Windoze. It should groom m_available_devices on device detach, but with Windows.... who knows.