### PR TITLE
Fix #128

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -11,6 +11,7 @@
 
 int main(int argc, char *argv[])
 {
+    QCoreApplication::addLibraryPath("./");
     init_signal_handlers(argv[0]);
 
     QGuiApplication app(argc, argv);


### PR DESCRIPTION
Forces Qt to use only the locally accessible libraries, ignoring system-wide installs. Verified this does not break operation on Linux.