### PR TITLE
Prevent config being written to ~/.config/Unknown Organization/pixelpulse2.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ To build / run on a generic POSIX platform
     cd pixelpulse2
     mkdir build
     cd build
-    qmake ..
+    qmake -qt=qt5 ..
     make
 
 To build / install for Debian, from the `pixelpulse2` directory:

--- a/main.cpp
+++ b/main.cpp
@@ -12,6 +12,10 @@
 int main(int argc, char *argv[])
 {
     QCoreApplication::addLibraryPath("./");
+
+    // Prevent config being written to ~/.config/Unknown Organization/pixelpulse2.conf
+    QCoreApplication::setOrganizationName("pixelpulse2");
+
     init_signal_handlers(argv[0]);
 
     QGuiApplication app(argc, argv);


### PR DESCRIPTION
On Linux, the file pixelpulse2.conf is written to directory "Unknown Organization" under ~/.config/ because the application doesn't set any organization name.  This 1-line addition to main.cpp sets QCore's organization to the name of the program, which is the standard convention for directories under ~/.config/ .

After the change, the config file will instead be written to ~/.config/pixelpulse2/pixelpulse2.conf