### PR TITLE
fix OSX nightly builds via Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_script: /usr/local/opt/qt5/bin/qmake
 script: 
 - make
 - /usr/local/opt/qt5/bin/macdeployqt pixelpulse2.app -dmg -always-overwrite -verbose=2 -qmldir=qml
-- curl -O /tmp/macdeployqtfix.py https://raw.githubusercontent.com/aurelien-rainone/macdeployqtfix/master/macdeployqtfix.py
+- curl -o /tmp/macdeployqtfix.py https://raw.githubusercontent.com/aurelien-rainone/macdeployqtfix/master/macdeployqtfix.py
 - python /tmp/macdeployqtfix.py /Volumes/pixelpulse2/pixelpulse2.app/Contents/MacOS/pixelpulse2 /usr/local/Cellar/qt5/5.5.0/
 - mkdir deploy
 - cp pixelpulse2.dmg deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_install:
 - brew update 2>&1 > /dev/null
 - brew install --build-from-source libusb 2>&1 > /dev/null
 - brew install qt5 2>&1 > /dev/null
-- brew linkapps qt5
+- brew link qt5 --force
 before_script: /usr/local/opt/qt5/bin/qmake
 script: 
 - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ os: osx
 osx_image: xcode61
 language: objective-c
 before_install:
-- brew update
-- brew install --build-from-source libusb
-- brew install qt5
+- brew update 2>&1 > /dev/null
+- brew install --build-from-source libusb 2>&1 > /dev/null
+- brew install qt5 2>&1 > /dev/null
 - brew linkapps qt5
 before_script: /usr/local/opt/qt5/bin/qmake
 script: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,10 @@ before_script: /usr/local/opt/qt5/bin/qmake
 script: 
 - make
 - /usr/local/opt/qt5/bin/macdeployqt pixelpulse2.app -dmg -always-overwrite -verbose=2 -qmldir=qml
+- hdiutil attach pixelpulse2.dmg
 - curl -o /tmp/macdeployqtfix.py https://raw.githubusercontent.com/aurelien-rainone/macdeployqtfix/master/macdeployqtfix.py
-- python /tmp/macdeployqtfix.py /Volumes/pixelpulse2/pixelpulse2.app/Contents/MacOS/pixelpulse2 /usr/local/Cellar/qt5/5.5.0/
+- python /tmp/macdeployqtfix.py /Volumes/pixelpulse2/pixelpulse2.app/Contents/MacOS/pixelpulse2 /usr/local/Cellar/qt5/5.5.0_1/
+- hdiutil detach /Volumes/pixelpulse2
 - mkdir deploy
 - cp pixelpulse2.dmg deploy
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ script:
 - make
 - /usr/local/opt/qt5/bin/macdeployqt pixelpulse2.app -always-overwrite -verbose=2 -qmldir=qml
 - curl -o /tmp/macdeployqtfix.py https://raw.githubusercontent.com/aurelien-rainone/macdeployqtfix/master/macdeployqtfix.py
-- python /tmp/macdeployqtfix.py /Volumes/pixelpulse2/pixelpulse2.app/Contents/MacOS/pixelpulse2 /usr/local/Cellar/qt5/5.5.0_1/
+- python /tmp/macdeployqtfix.py ./pixelpulse2.app/Contents/MacOS/pixelpulse2 /usr/local/Cellar/qt5/5.5.0_1/
 - /usr/local/opt/qt5/bin/macdeployqt pixelpulse2.app -dmg -no-plugins
 - mkdir deploy
 - cp pixelpulse2.dmg deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,10 @@ before_install:
 before_script: /usr/local/opt/qt5/bin/qmake
 script: 
 - make
-- /usr/local/opt/qt5/bin/macdeployqt pixelpulse2.app -dmg -always-overwrite -verbose=2 -qmldir=qml
-- hdiutil attach pixelpulse2.dmg
+- /usr/local/opt/qt5/bin/macdeployqt pixelpulse2.app -always-overwrite -verbose=2 -qmldir=qml
 - curl -o /tmp/macdeployqtfix.py https://raw.githubusercontent.com/aurelien-rainone/macdeployqtfix/master/macdeployqtfix.py
 - python /tmp/macdeployqtfix.py /Volumes/pixelpulse2/pixelpulse2.app/Contents/MacOS/pixelpulse2 /usr/local/Cellar/qt5/5.5.0_1/
-- hdiutil detach /Volumes/pixelpulse2
+- /usr/local/opt/qt5/bin/macdeployqt pixelpulse2.app -dmg -no-plugins
 - mkdir deploy
 - cp pixelpulse2.dmg deploy
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ before_script: /usr/local/opt/qt5/bin/qmake
 script: 
 - make
 - /usr/local/opt/qt5/bin/macdeployqt pixelpulse2.app -dmg -always-overwrite -verbose=2 -qmldir=qml
+- curl -O /tmp/macdeployqtfix.py https://raw.githubusercontent.com/aurelien-rainone/macdeployqtfix/master/macdeployqtfix.py
+- python /tmp/macdeployqtfix.py /Volumes/pixelpulse2/pixelpulse2.app/Contents/MacOS/pixelpulse2 /usr/local/Cellar/qt5/5.5.0/
 - mkdir deploy
 - cp pixelpulse2.dmg deploy
 deploy:


### PR DESCRIPTION
As per https://github.com/analogdevicesinc/Pixelpulse2/issues/142, need to use macdeployqtfix.py to fix the .app generated by qmake, prior to packing as a .dmg.