### PR TITLE
Fix SSL on Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ install:
   - 7z x -y "c:\mingw.7z" -o"C:\" > nul
   - ps: (new-object System.Net.WebClient).Downloadfile("http://sourceforge.net/projects/mingw-w64/files/External%20binary%20packages%20%28Win64%20hosted%29/MSYS%20%2832-bit%29/MSYS-20111123.zip", "c:\msys.zip")
   - 7z x -y "c:\msys.zip" -o"C:\" > nul
-  - set QTDIR=C:\Qt\5.4\mingw491_32
+  - set QTDIR=C:\Qt\5.5\mingw492_32
   - set PATH=C:\Program Files (x86)\MSBuild\12.0\bin\;C:\mingw32\bin;C:\msys\bin\;%QTDIR%\bin;%PATH%
   - ps: (new-object System.Net.WebClient).Downloadfile("http://itdaniher.com/static/libusb-1.0-hp.7z", "c:\libusb.7z")
   - 7z x -y "c:\libusb.7z" -o"C:\libusb" > nul

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,9 +10,10 @@ install:
   - 7z x -y "c:\mingw.7z" -o"C:\" > nul
   - ps: (new-object System.Net.WebClient).Downloadfile("http://sourceforge.net/projects/mingw-w64/files/External%20binary%20packages%20%28Win64%20hosted%29/MSYS%20%2832-bit%29/MSYS-20111123.zip", "c:\msys.zip")
   - 7z x -y "c:\msys.zip" -o"C:\" > nul
-  - set QTDIR=C:\Qt\5.5\mingw492_32
+#  - set QTDIR=C:\Qt\5.5\mingw492_32
+  - set QTDIR=C:\Qt\5.4\mingw491_32
   - dir %QTDIR%\bin
-  - '%QTDIR%\bin\qtenv2.bat'
+#  - '%QTDIR%\bin\qtenv2.bat'
   - set PATH=C:\Program Files (x86)\MSBuild\12.0\bin\;C:\mingw32\bin;C:\msys\bin\;%QTDIR%\bin;%PATH%
   - ps: (new-object System.Net.WebClient).Downloadfile("http://itdaniher.com/static/libusb-1.0-hp.7z", "c:\libusb.7z")
   - 7z x -y "c:\libusb.7z" -o"C:\libusb" > nul

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,12 +3,16 @@ os: unstable
 platform:
  - x86
 
+# http://iweb.dl.sourceforge.net/project/mingw-w64/Toolchains%20targetting%20Win32/Personal%20Builds/mingw-builds/4.9.3/threads-posix/dwarf/i686-4.9.3-release-posix-dwarf-rt_v4-rev1.7z
+
 install:
   - ps: (new-object System.Net.WebClient).Downloadfile("http://iweb.dl.sourceforge.net/project/mingw-w64/Toolchains%20targetting%20Win32/Personal%20Builds/mingw-builds/5.2.0/threads-posix/dwarf/i686-5.2.0-release-posix-dwarf-rt_v4-rev0.7z", "c:\mingw.7z")
   - 7z x -y "c:\mingw.7z" -o"C:\" > nul
   - ps: (new-object System.Net.WebClient).Downloadfile("http://sourceforge.net/projects/mingw-w64/files/External%20binary%20packages%20%28Win64%20hosted%29/MSYS%20%2832-bit%29/MSYS-20111123.zip", "c:\msys.zip")
   - 7z x -y "c:\msys.zip" -o"C:\" > nul
   - set QTDIR=C:\Qt\5.5\mingw492_32
+  - dir %QTDIR%\bin
+  - '%QTDIR%\bin\qtenv2.bat'
   - set PATH=C:\Program Files (x86)\MSBuild\12.0\bin\;C:\mingw32\bin;C:\msys\bin\;%QTDIR%\bin;%PATH%
   - ps: (new-object System.Net.WebClient).Downloadfile("http://itdaniher.com/static/libusb-1.0-hp.7z", "c:\libusb.7z")
   - 7z x -y "c:\libusb.7z" -o"C:\libusb" > nul
@@ -30,6 +34,6 @@ after_build:
     appveyor PushArtifact distrib.zip
 
 cache:
- - distrib.zip -> pixelpulse2.pro
- - c:\mingw.7z -> pixelpulse2.pro
- - c:\msys.zip -> pixelpulse2.pro
+ - distrib.zip -> appveyor.yml
+ - c:\mingw.7z -> appveyor.yml
+ - c:\msys.zip -> appveyor.yml

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,7 @@ build_script:
 after_build:
 - ps: |
     If (!(Test-Path -Path "distrib.zip")) {
-      windeployqt --qmldir qml release\pixelpulse2.exe --dir distrib
+      windeployqt --qmldir qml release\pixelpulse2.exe --dir distrib --compiler-runtime
       cp C:\OpenSSL-Win32\libeay32.dll distrib
       cp C:\OpenSSL-Win32\libssl32.dll distrib
       cp C:\OpenSSL-Win32\ssleay32.dll distrib

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ platform:
  - x86
 
 install:
-  - ps: (new-object System.Net.WebClient).Downloadfile("https://downloads.sourceforge.net/project/mingw-w64/Toolchains%20targetting%20Win32/Personal%20Builds/mingw-builds/4.9.2/threads-posix/dwarf/i686-4.9.2-release-posix-dwarf-rt_v3-rev0.7z", "c:\mingw.7z")
+  - ps: (new-object System.Net.WebClient).Downloadfile("http://iweb.dl.sourceforge.net/project/mingw-w64/Toolchains%20targetting%20Win32/Personal%20Builds/mingw-builds/5.2.0/threads-posix/dwarf/i686-5.2.0-release-posix-dwarf-rt_v4-rev0.7z", "c:\mingw.7z")
   - 7z x -y "c:\mingw.7z" -o"C:\" > nul
   - ps: (new-object System.Net.WebClient).Downloadfile("http://sourceforge.net/projects/mingw-w64/files/External%20binary%20packages%20%28Win64%20hosted%29/MSYS%20%2832-bit%29/MSYS-20111123.zip", "c:\msys.zip")
   - 7z x -y "c:\msys.zip" -o"C:\" > nul

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,8 @@ install:
   - set PATH=C:\Program Files (x86)\MSBuild\12.0\bin\;C:\mingw32\bin;C:\msys\bin\;%QTDIR%\bin;%PATH%
   - ps: (new-object System.Net.WebClient).Downloadfile("http://itdaniher.com/static/libusb-1.0-hp.7z", "c:\libusb.7z")
   - 7z x -y "c:\libusb.7z" -o"C:\libusb" > nul
+  - appveyor DownloadFile https://slproweb.com/download/Win32OpenSSL_Light-1_0_2d.exe
+  - Win32OpenSSL_Light-1_0_2d.exe /silent /verysilent /sp- /suppressmsgboxes
 
 build_script:
   - git submodule update --init --recursive

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,8 +9,6 @@ install:
   - ps: (new-object System.Net.WebClient).Downloadfile("http://sourceforge.net/projects/mingw-w64/files/External%20binary%20packages%20%28Win64%20hosted%29/MSYS%20%2832-bit%29/MSYS-20111123.zip", "c:\msys.zip")
   - 7z x -y "c:\msys.zip" -o"C:\" > nul
   - set QTDIR=C:\Qt\5.4\mingw491_32
-  - dir C:\Qt
-#  - '%QTDIR%\bin\qtenv2.bat'
   - set PATH=C:\Program Files (x86)\MSBuild\12.0\bin\;C:\mingw32\bin;C:\msys\bin\;%QTDIR%\bin;%PATH%
   - ps: (new-object System.Net.WebClient).Downloadfile("http://itdaniher.com/static/libusb-1.0-hp.7z", "c:\libusb.7z")
   - 7z x -y "c:\libusb.7z" -o"C:\libusb" > nul
@@ -30,6 +28,7 @@ after_build:
       cp C:\OpenSSL-Win32\libssl32.dll distrib
       cp C:\OpenSSL-Win32\ssleay32.dll distrib
       cp C:\Windows\System32\msvcr120.dll distrib
+      cp C:\Windows\System32\msvcp120.dll distrib
       7z a -y distrib.zip distrib
     }
     appveyor PushArtifact release\pixelpulse2.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-os: unstable
+os: Windows Server 2012 R2
 
 platform:
  - x86
@@ -25,10 +25,11 @@ build_script:
 after_build:
 - ps: |
     If (!(Test-Path -Path "distrib.zip")) {
-      windeployqt --qmldir qml release\pixelpulse2.exe --dir distrib --compiler-runtime
+      windeployqt --qmldir qml release\pixelpulse2.exe --dir distrib
       cp C:\OpenSSL-Win32\libeay32.dll distrib
       cp C:\OpenSSL-Win32\libssl32.dll distrib
       cp C:\OpenSSL-Win32\ssleay32.dll distrib
+      cp C:\Windows\System32\msvcr120.dll distrib
       7z a -y distrib.zip distrib
     }
     appveyor PushArtifact release\pixelpulse2.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,16 +3,13 @@ os: unstable
 platform:
  - x86
 
-# http://iweb.dl.sourceforge.net/project/mingw-w64/Toolchains%20targetting%20Win32/Personal%20Builds/mingw-builds/4.9.3/threads-posix/dwarf/i686-4.9.3-release-posix-dwarf-rt_v4-rev1.7z
-
 install:
   - ps: (new-object System.Net.WebClient).Downloadfile("http://iweb.dl.sourceforge.net/project/mingw-w64/Toolchains%20targetting%20Win32/Personal%20Builds/mingw-builds/5.2.0/threads-posix/dwarf/i686-5.2.0-release-posix-dwarf-rt_v4-rev0.7z", "c:\mingw.7z")
   - 7z x -y "c:\mingw.7z" -o"C:\" > nul
   - ps: (new-object System.Net.WebClient).Downloadfile("http://sourceforge.net/projects/mingw-w64/files/External%20binary%20packages%20%28Win64%20hosted%29/MSYS%20%2832-bit%29/MSYS-20111123.zip", "c:\msys.zip")
   - 7z x -y "c:\msys.zip" -o"C:\" > nul
-#  - set QTDIR=C:\Qt\5.5\mingw492_32
   - set QTDIR=C:\Qt\5.4\mingw491_32
-  - dir %QTDIR%\bin
+  - dir C:\Qt
 #  - '%QTDIR%\bin\qtenv2.bat'
   - set PATH=C:\Program Files (x86)\MSBuild\12.0\bin\;C:\mingw32\bin;C:\msys\bin\;%QTDIR%\bin;%PATH%
   - ps: (new-object System.Net.WebClient).Downloadfile("http://itdaniher.com/static/libusb-1.0-hp.7z", "c:\libusb.7z")
@@ -29,6 +26,9 @@ after_build:
 - ps: |
     If (!(Test-Path -Path "distrib.zip")) {
       windeployqt --qmldir qml release\pixelpulse2.exe --dir distrib
+      cp C:\OpenSSL-Win32\libeay32.dll distrib
+      cp C:\OpenSSL-Win32\libssl32.dll distrib
+      cp C:\OpenSSL-Win32\ssleay32.dll distrib
       7z a -y distrib.zip distrib
     }
     appveyor PushArtifact release\pixelpulse2.exe


### PR DESCRIPTION
SSL-related error messages were being printed to the console on Windows. As no executable code was being loaded over the network, SSL was merely "nice to have," not required, and these messages could be safely ignored.

As automatic firmware updating makes it into master, version numbers, checksums, and binary blobs should be loaded only over a secured connection. Given how broken the modern web of trust is, I'm considering certificate pinning via QSslSocket::addCaCertificate, but that might be overkill....

This pull request modifies the Appveyor build script to fetch Win32OpenSSL_Light and bundle the requisite DLLs into distrib.zip.