### PR TITLE
fix bug in dataexport.js

### DIFF
--- a/qml/dataexport.js
+++ b/qml/dataexport.js
@@ -25,7 +25,7 @@ var dumpSamples = function (columns, labels) {
 var saveData = function (target) {
     var labels = [];
     var columns = [];
-    if (session.devices) {
+    if (session.devices.length) {
         for (var i = 0; i < session.devices.length; i++) {
             for (var j = 0; j < session.devices[i].channels.length; j++) {
                 for (var k = 0; k < session.devices[i].channels[i].signals.length; k++) {


### PR DESCRIPTION
Empty `object`s are evaluated as `true` not `false` in JS.

The iteration loop 

` for (var i = 0; i < session.devices.length; i++) `

never breaks if `session.devices.length == 0`, resulting in an out of memory error.

This is addressed by explicitly checking session.devices.length before entering the loop.