### PR TITLE
pixelpulse2.pro: force qmake to determine the right header path

### DIFF
--- a/pixelpulse2.pro
+++ b/pixelpulse2.pro
@@ -74,7 +74,6 @@ win32:debug {
 osx {
 	ICON = icons/pp2.icns
         LIBS += -lobjc -framework IOKit -framework CoreFoundation
-        INCLUDEPATH += /usr/local/opt/qt5/include
         QT_LOGGING_RULES=qt.network.ssl.warning=false
 }
 


### PR DESCRIPTION
On systems with multiple versions of Qt installed, this generic
hardcoded path can be for a Qt version that doesn't correspond to the
qmake version being used. In this situation, the build often breaks due
to the incorrect QT_VERSION causing various conditional macros to error
out.