### PR TITLE
Removed libusb hotplug and solved the crash on close bug.

### DIFF
--- a/Plot/FloatBuffer.h
+++ b/Plot/FloatBuffer.h
@@ -68,7 +68,7 @@ public:
     {
         int num_samples_to_add = samples.size();
         if(m_length > maxSize){
-            m_data.erase(m_data.begin(),m_data.begin()+num_samples_to_add);
+            m_data.erase(m_data.begin(),std::min(m_data.end(), m_data.begin()+num_samples_to_add));
             for(int i=0;i<num_samples_to_add;i++){
                 m_data.push_back(samples[i][signal_index]);
             }

--- a/SMU.cpp
+++ b/SMU.cpp
@@ -265,7 +265,7 @@ void SessionItem::getSamples()
         std::vector<std::array<float, 4>> rxbuf;
         int ret = 0;
         try {
-            ret = dev->m_device->read(rxbuf, 1000);
+            ret = dev->m_device->read(rxbuf, 10000);
         } catch (std::system_error& e) {
             qDebug() << "exception:" << e.what();
         } catch (std::runtime_error& e) {

--- a/SMU.h
+++ b/SMU.h
@@ -54,6 +54,7 @@ public:
     bool isContinuous(){return m_continuous;}
     bool getActive() { return m_active; }
     QQmlListProperty<DeviceItem> getDevices() { return QQmlListProperty<DeviceItem>(this, m_devices); }
+    static void usb_handle_thread_method(SessionItem *session_item);
 
 signals:
     void devicesChanged();

--- a/main.cpp
+++ b/main.cpp
@@ -26,7 +26,6 @@ int main(int argc, char *argv[])
 
     FileIO fileIO;
     SessionItem smu_session;
-    smu_session.openAllDevices();
     engine.rootContext()->setContextProperty("session", &smu_session);
 
     QVariantMap versions;


### PR DESCRIPTION
In the latest libsmu version we have changed the hotplug mechanism. This is because in the last versions of libusb, they have changed the way it works. On the latest versions, when a hotplug signal is emitted (and the callback is started), the device becomes busy, until the callback ends. This thing makes the hotplug mechanism from libsmu inoperative, because it is (almost) impossible to synchronize the callback end time and libsmu calls on the device. When this branch will be merged into master, we will not use the old version of libusb anymore and will use the latest available libusb version (link to the libusb github repository: https://github.com/libusb/libusb).

Therefore we have removed the hotplug_attach and hotplug_detach methods from libsmu and the "-p, --hotplug-devices" option from the API.

In this version, we check every 2 seconds if there are any newly attached/detached devices. We are checking this thing on a new thread, which keeps the old devices list (from 2 seconds ago) and compares it with the newly read devices list. If it finds a new/old device, it emits a attached/detached signal, which is handled by the rest of the program, exactly the same way it was handled before. 

Signed-off-by: Cristi Iacob <cristian.iacob@analog.com>