### PR TITLE
Added find device by led functionality.

### DIFF
--- a/SMU.cpp
+++ b/SMU.cpp
@@ -433,6 +433,17 @@ m_samples_added(0)
     }
 }
 
+void DeviceItem::blinkLeds()
+{
+    m_device->set_led(1);
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    m_device->set_led(2);
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    m_device->set_led(1);
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    m_device->set_led(2);
+}
+
 
 void DeviceItem::write(ChannelItem* channel)
 {

--- a/SMU.cpp
+++ b/SMU.cpp
@@ -1,6 +1,7 @@
 #include <QStandardPaths>
 #include <QDir>
 #include <iomanip>
+#include <thread>
 
 #include "SMU.h"
 #include "Plot/PhosphorRender.h"
@@ -435,15 +436,18 @@ m_samples_added(0)
 
 void DeviceItem::blinkLeds()
 {
-    m_device->set_led(1);
-    std::this_thread::sleep_for(std::chrono::milliseconds(500));
-    m_device->set_led(2);
-    std::this_thread::sleep_for(std::chrono::milliseconds(500));
-    m_device->set_led(1);
-    std::this_thread::sleep_for(std::chrono::milliseconds(500));
-    m_device->set_led(2);
+    std::thread led_thread ([=] {
+        this->m_device->set_led(1);
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+        this->m_device->set_led(2);
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+        this->m_device->set_led(1);
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+        this->m_device->set_led(2);
+        }
+    );
+    led_thread.detach();
 }
-
 
 void DeviceItem::write(ChannelItem* channel)
 {

--- a/SMU.h
+++ b/SMU.h
@@ -122,6 +122,7 @@ public:
     int getDefaultRate() { return m_device->get_default_rate(); }
     friend class DataLogger;
     Q_INVOKABLE int ctrl_transfer( int x, int y, int z) { return m_device->ctrl_transfer(0x40, x, y, z, 0, 0, 100);}
+    Q_INVOKABLE void blinkLeds();
 
     size_t samplesAdded() { return m_samples_added; }
     void setSamplesAdded(size_t count) { m_samples_added = count; }

--- a/qml/DeviceRow.qml
+++ b/qml/DeviceRow.qml
@@ -18,6 +18,13 @@ Rectangle {
     x: (timelinePane.spacing - height) / 2
   }
 
+  MouseArea {
+      anchors.fill: parent
+      onClicked: {
+          session.devices[currentIndex].blinkLeds()
+      }
+  }
+
   ColumnLayout {
     anchors.fill: parent
     anchors.leftMargin: timelinePane.spacing


### PR DESCRIPTION
You can now spot each device from the GUI by clicking each of the ADALM1000 labels from the left of the screen.
The corresponding device's leds will blink.

Signed-off-by: Cristi Iacob <cristian.iacob@analog.com>