### PR TITLE
Data logger

### DIFF
--- a/SMU.cpp
+++ b/SMU.cpp
@@ -731,6 +731,7 @@ void DataLogger::resetData(DeviceItem* deviceItem)
 
 void DataLogger::addData(DeviceItem * deviceItem, std::array<float, 4> samples)
 {
+    m_logMutex.lock();
     if (dataCounter[deviceItem] == 0) {
         resetData(deviceItem);
     }
@@ -749,6 +750,7 @@ void DataLogger::addData(DeviceItem * deviceItem, std::array<float, 4> samples)
             resetData(pair.first);
         }
     }
+    m_logMutex.unlock();
 }
 
 void DataLogger::addBulkData(DeviceItem* deviceItem, std::vector<std::array<float, 4> > buff)

--- a/SMU.cpp
+++ b/SMU.cpp
@@ -657,7 +657,9 @@ void BufferChanger::changeBuffer(){
 
 DataLogger::DataLogger(float sampleTime)
 {
-    if (sampleTime != -1) {
+    //if created by a valid session (1s or 10s sample time), create the log file
+    if (sampleTime != -1
+            && !(fabs(sampleTime - 0.01) < 0.00001 || fabs(sampleTime - 0.1) < 0.00001)) {
         this->sampleTime = sampleTime;
         auto current_time = std::chrono::system_clock::now();
         std::time_t time = std::chrono::system_clock::to_time_t(current_time);

--- a/SMU.cpp
+++ b/SMU.cpp
@@ -38,13 +38,17 @@ m_active(false),
 m_continuous(false),
 m_sample_rate(0),
 m_sample_count(0),
-m_queue_size(1000000)
+m_queue_size(1000000),
+m_data_logger(new DataLogger(-1)),
+m_logging(0)
 {
     connect(this, &SessionItem::finished, this, &SessionItem::onFinished, Qt::QueuedConnection);
     connect(this, &SessionItem::attached, this, &SessionItem::onAttached, Qt::QueuedConnection);
     connect(this, &SessionItem::detached, this, &SessionItem::onDetached, Qt::QueuedConnection);
 
     connect(this, &SessionItem::sampleCountChanged, this, &SessionItem::onSampleCountChanged);
+    connect(this, &SessionItem::loggingChanged, this, &SessionItem::onLoggingChanged);
+    connect(this, &SessionItem::sampleTimeChanged, this, &SessionItem::onSampleTimeChanged);
     connect(&timer, SIGNAL(timeout()), this, SLOT(getSamples()));
 
     std::thread usb_thread(usb_handle_thread_method, this);
@@ -55,8 +59,9 @@ m_queue_size(1000000)
 }
 
 SessionItem::~SessionItem() {
-    Q_ASSERT(m_devices.size() == 0);
-	delete sweepTimer;
+        Q_ASSERT(m_devices.size() == 0);
+        delete sweepTimer;
+        delete this->m_data_logger;
 }
 
 
@@ -92,6 +97,11 @@ qDebug() << "Session start(" << continuous << ")";
     m_session->flush();
     m_session->configure(m_sample_rate);
     m_continuous = continuous;
+
+    if (m_logging == 1) {
+        delete m_data_logger;
+        m_data_logger = new DataLogger(m_sample_time);
+    }
 
     for (auto dev: m_devices) {
         dev->setSamplesAdded(0);
@@ -157,6 +167,19 @@ void SessionItem::onDetached(Device* device){
 
 void SessionItem::onSampleCountChanged(){
     restart();
+}
+
+void SessionItem::onSampleTimeChanged() {
+    m_data_logger->setSampleTime(m_sample_time);
+}
+
+void SessionItem::onLoggingChanged()
+{
+    if (m_logging == 0) {
+        m_logging = 1;
+    } else {
+        m_logging = 0;
+    }
 }
 
 void SessionItem::handleDownloadedFirmware()
@@ -288,6 +311,12 @@ void SessionItem::getSamples()
                 else
                     sig->m_buffer->append_samples(rxbuf, i * 2 + j);
                 j++;
+            }
+
+            if (m_logging) {
+                for (auto it : rxbuf) {
+                    this->m_data_logger->addData(dev, {it[0], it[1], it[2], it[3]});
+                }
             }
             i++;
         }
@@ -620,4 +649,109 @@ void BufferChanger::changeBuffer(){
 
     device->write(channel);
     this->thread()->quit();
+}
+
+DataLogger::DataLogger(double sampleTime)
+{
+    if (sampleTime != -1) {
+        this->sampleTime = sampleTime;
+        auto current_time = std::chrono::system_clock::now();
+        std::time_t time = std::chrono::system_clock::to_time_t(current_time);
+        string timeString = "logging/PP_Log_";
+        timeString.append(modifyDateTime(std::ctime(&time)));
+        timeString.append(".csv");
+        fileStream.open(timeString.c_str(), std::ios::out);
+        startTime = std::chrono::system_clock::now();
+        lastLog = startTime;
+        fileStream << "Timestamp,Device serial,Min V ch A,Min A ch A,Min V ch B,Min A ch B,Max V ch A,Max A ch A,Max V ch B,Max A ch B,Avg V ch A,Avg A ch A,Avg V ch B,Avg A ch B\n";
+        fileStream.flush();
+    }
+}
+
+string DataLogger::modifyDateTime(string dateTime)
+{
+    std::map < string, string > months = {{"Jan", "01"}, {"Feb", "02"}, {"Mar", "03"}, {"Apr", "04"}, {"May", "05"}, {"Jun", "06"},
+                                          {"Jul", "07"}, {"Aug", "08"}, {"Sep", "09"}, {"Oct", "10"}, {"Nov", "11"}, {"Dec", "12"}};
+    string year = dateTime.substr(20, 4);
+    string month = months[dateTime.substr(4, 3)];
+    string day = dateTime.substr(8, 2);
+    if (std::stoi(day) < 10)
+        day[0] = '0';
+    string hour = dateTime.substr(11, 2);
+    string minute = dateTime.substr(14, 2);
+    string second = dateTime.substr(17, 2);
+    return year + month + day + hour + minute + second;
+}
+
+void DataLogger::updateMinimum(DeviceItem* deviceItem, std::array<double, 4> samples)
+{
+    minimum[deviceItem][0] = std::min(samples[0], minimum[deviceItem][0]);
+    minimum[deviceItem][1] = std::min(samples[1], minimum[deviceItem][1]);
+    minimum[deviceItem][2] = std::min(samples[2], minimum[deviceItem][2]);
+    minimum[deviceItem][3] = std::min(samples[3], minimum[deviceItem][3]);
+}
+
+void DataLogger::updateMaximum(DeviceItem * deviceItem, std::array<double, 4> samples)
+{
+    maximum[deviceItem][0] = std::max(samples[0], maximum[deviceItem][0]);
+    maximum[deviceItem][1] = std::max(samples[1], maximum[deviceItem][1]);
+    maximum[deviceItem][2] = std::max(samples[2], maximum[deviceItem][2]);
+    maximum[deviceItem][3] = std::max(samples[3], maximum[deviceItem][3]);
+}
+
+void DataLogger::updateSum(DeviceItem * deviceItem, std::array<double, 4> samples)
+{
+    sum[deviceItem][0] += samples[0];
+    sum[deviceItem][1] += samples[1];
+    sum[deviceItem][2] += samples[2];
+    sum[deviceItem][3] += samples[3];
+}
+
+std::array < double, 4 > DataLogger::computeAverage(DeviceItem * deviceItem)
+{
+    return {sum[deviceItem][0] / dataCounter[deviceItem], sum[deviceItem][1] / dataCounter[deviceItem],
+                sum[deviceItem][2] / dataCounter[deviceItem], sum[deviceItem][3] / dataCounter[deviceItem]};
+}
+
+void DataLogger::resetData(DeviceItem* deviceItem)
+{
+    dataCounter[deviceItem] = 0;
+    minimum[deviceItem] = {100, 100, 100, 100};
+    maximum[deviceItem] = {-100, -100, -100, -100};
+    sum[deviceItem] = {0, 0, 0, 0};
+}
+
+void DataLogger::addData(DeviceItem * deviceItem, std::array<double, 4> samples)
+{
+    dataCounter[deviceItem] ++;
+    updateMinimum(deviceItem, samples);
+    updateMaximum(deviceItem, samples);
+    updateSum(deviceItem, samples);
+    std::chrono::duration < double > timeDiff = std::chrono::system_clock::now() - lastLog;
+
+    if (timeDiff.count() >= sampleTime) {
+        lastLog = std::chrono::system_clock::now();
+        printData(deviceItem);
+        resetData(deviceItem);
+    }
+}
+
+void DataLogger::printData(DeviceItem* deviceItem)
+{
+    string deviceSerial = deviceItem->m_device->m_serial;
+    deviceSerial = deviceSerial.substr(deviceSerial.size() - 5, 5);
+    std::chrono::duration < double > timeDiff = std::chrono::system_clock::now() - startTime;
+
+    std::array < double, 4 > average = computeAverage(deviceItem);
+
+    fileStream <<  timeDiff.count() << "," << deviceSerial << ","
+                     << minimum[deviceItem][0] << "," << minimum[deviceItem][1] << "," << minimum[deviceItem][2] << "," << minimum[deviceItem][3] << ","
+                     << maximum[deviceItem][0] << "," << maximum[deviceItem][1] << "," << maximum[deviceItem][2] << "," << maximum[deviceItem][3] << ","
+                     << average[0] << "," << average[1] << "," << average[2] << "," << average[3] << '\n';
+    fileStream.flush();
+}
+
+void DataLogger::setSampleTime(double sampleTime)
+{
+    this->sampleTime = sampleTime;
 }

--- a/SMU.cpp
+++ b/SMU.cpp
@@ -723,6 +723,10 @@ void DataLogger::resetData(DeviceItem* deviceItem)
 
 void DataLogger::addData(DeviceItem * deviceItem, std::array<double, 4> samples)
 {
+    if (dataCounter[deviceItem] == 0) {
+        resetData(deviceItem);
+    }
+
     dataCounter[deviceItem] ++;
     updateMinimum(deviceItem, samples);
     updateMaximum(deviceItem, samples);

--- a/SMU.cpp
+++ b/SMU.cpp
@@ -656,6 +656,7 @@ DataLogger::DataLogger(float sampleTime)
         this->sampleTime = sampleTime;
         auto current_time = std::chrono::system_clock::now();
         std::time_t time = std::chrono::system_clock::to_time_t(current_time);
+        createLoggingFolder();
         string timeString = "logging/PP_Log_";
         timeString.append(modifyDateTime(std::ctime(&time)));
         timeString.append(".csv");
@@ -766,4 +767,11 @@ void DataLogger::printData(DeviceItem* deviceItem)
 void DataLogger::setSampleTime(float sampleTime)
 {
     this->sampleTime = sampleTime;
+}
+
+void DataLogger::createLoggingFolder()
+{
+    if (!QDir("logging").exists()) {
+        QDir().mkdir("logging");
+    }
 }

--- a/SMU.cpp
+++ b/SMU.cpp
@@ -651,7 +651,7 @@ void BufferChanger::changeBuffer(){
     this->thread()->quit();
 }
 
-DataLogger::DataLogger(double sampleTime)
+DataLogger::DataLogger(float sampleTime)
 {
     if (sampleTime != -1) {
         this->sampleTime = sampleTime;
@@ -683,7 +683,7 @@ string DataLogger::modifyDateTime(string dateTime)
     return year + month + day + hour + minute + second;
 }
 
-void DataLogger::updateMinimum(DeviceItem* deviceItem, std::array<double, 4> samples)
+void DataLogger::updateMinimum(DeviceItem* deviceItem, std::array<float, 4> samples)
 {
     minimum[deviceItem][0] = std::min(samples[0], minimum[deviceItem][0]);
     minimum[deviceItem][1] = std::min(samples[1], minimum[deviceItem][1]);
@@ -691,7 +691,7 @@ void DataLogger::updateMinimum(DeviceItem* deviceItem, std::array<double, 4> sam
     minimum[deviceItem][3] = std::min(samples[3], minimum[deviceItem][3]);
 }
 
-void DataLogger::updateMaximum(DeviceItem * deviceItem, std::array<double, 4> samples)
+void DataLogger::updateMaximum(DeviceItem * deviceItem, std::array<float, 4> samples)
 {
     maximum[deviceItem][0] = std::max(samples[0], maximum[deviceItem][0]);
     maximum[deviceItem][1] = std::max(samples[1], maximum[deviceItem][1]);
@@ -699,7 +699,7 @@ void DataLogger::updateMaximum(DeviceItem * deviceItem, std::array<double, 4> sa
     maximum[deviceItem][3] = std::max(samples[3], maximum[deviceItem][3]);
 }
 
-void DataLogger::updateSum(DeviceItem * deviceItem, std::array<double, 4> samples)
+void DataLogger::updateSum(DeviceItem * deviceItem, std::array<float, 4> samples)
 {
     sum[deviceItem][0] += samples[0];
     sum[deviceItem][1] += samples[1];
@@ -707,7 +707,7 @@ void DataLogger::updateSum(DeviceItem * deviceItem, std::array<double, 4> sample
     sum[deviceItem][3] += samples[3];
 }
 
-std::array < double, 4 > DataLogger::computeAverage(DeviceItem * deviceItem)
+std::array < float, 4 > DataLogger::computeAverage(DeviceItem * deviceItem)
 {
     return {sum[deviceItem][0] / dataCounter[deviceItem], sum[deviceItem][1] / dataCounter[deviceItem],
                 sum[deviceItem][2] / dataCounter[deviceItem], sum[deviceItem][3] / dataCounter[deviceItem]};
@@ -721,7 +721,7 @@ void DataLogger::resetData(DeviceItem* deviceItem)
     sum[deviceItem] = {0, 0, 0, 0};
 }
 
-void DataLogger::addData(DeviceItem * deviceItem, std::array<double, 4> samples)
+void DataLogger::addData(DeviceItem * deviceItem, std::array<float, 4> samples)
 {
     if (dataCounter[deviceItem] == 0) {
         resetData(deviceItem);
@@ -746,7 +746,7 @@ void DataLogger::printData(DeviceItem* deviceItem)
     deviceSerial = deviceSerial.substr(deviceSerial.size() - 5, 5);
     std::chrono::duration < double > timeDiff = std::chrono::system_clock::now() - startTime;
 
-    std::array < double, 4 > average = computeAverage(deviceItem);
+    std::array < float, 4 > average = computeAverage(deviceItem);
 
     fileStream <<  timeDiff.count() << "," << deviceSerial << ","
                      << minimum[deviceItem][0] << "," << minimum[deviceItem][1] << "," << minimum[deviceItem][2] << "," << minimum[deviceItem][3] << ","
@@ -755,7 +755,7 @@ void DataLogger::printData(DeviceItem* deviceItem)
     fileStream.flush();
 }
 
-void DataLogger::setSampleTime(double sampleTime)
+void DataLogger::setSampleTime(float sampleTime)
 {
     this->sampleTime = sampleTime;
 }

--- a/SMU.cpp
+++ b/SMU.cpp
@@ -177,6 +177,11 @@ void SessionItem::onLoggingChanged()
 {
     if (m_logging == 0) {
         m_logging = 1;
+
+        if (m_active) {
+            delete m_data_logger;
+            m_data_logger = new DataLogger(m_sample_time);
+        }
     } else {
         m_logging = 0;
     }

--- a/SMU.cpp
+++ b/SMU.cpp
@@ -314,9 +314,8 @@ void SessionItem::getSamples()
             }
 
             if (m_logging) {
-                for (auto it : rxbuf) {
-                    this->m_data_logger->addData(dev, {it[0], it[1], it[2], it[3]});
-                }
+                std::thread t1([=] {this->m_data_logger->addBulkData(dev, rxbuf);});
+                t1.detach();
             }
             i++;
         }
@@ -735,9 +734,18 @@ void DataLogger::addData(DeviceItem * deviceItem, std::array<float, 4> samples)
 
     if (timeDiff.count() >= sampleTime) {
         lastLog = std::chrono::system_clock::now();
-        printData(deviceItem);
-        resetData(deviceItem);
+        //Log data for all available devices.
+        for (auto pair : sum) {
+            printData(pair.first);
+            resetData(pair.first);
+        }
     }
+}
+
+void DataLogger::addBulkData(DeviceItem* deviceItem, std::vector<std::array<float, 4> > buff)
+{
+    for (auto sample : buff)
+        addData(deviceItem, sample);
 }
 
 void DataLogger::printData(DeviceItem* deviceItem)

--- a/SMU.cpp
+++ b/SMU.cpp
@@ -1,5 +1,6 @@
 #include <QStandardPaths>
 #include <QDir>
+#include <iomanip>
 
 #include "SMU.h"
 #include "Plot/PhosphorRender.h"
@@ -764,7 +765,7 @@ void DataLogger::printData(DeviceItem* deviceItem)
 
     std::array < float, 4 > average = computeAverage(deviceItem);
 
-    fileStream <<  timeDiff.count() << "," << deviceSerial << ","
+    fileStream << setprecision(3) << fixed << timeDiff.count() << "," << deviceSerial << ","
                      << minimum[deviceItem][0] << "," << minimum[deviceItem][1] << "," << minimum[deviceItem][2] << "," << minimum[deviceItem][3] << ","
                      << maximum[deviceItem][0] << "," << maximum[deviceItem][1] << "," << maximum[deviceItem][2] << "," << maximum[deviceItem][3] << ","
                      << average[0] << "," << average[1] << "," << average[2] << "," << average[3] << '\n';

--- a/SMU.h
+++ b/SMU.h
@@ -324,25 +324,25 @@ void registerTypes();
 
 class DataLogger {
 public:
-    DataLogger(double sampleTime);
-    void addData(DeviceItem*, std::array < double, 4 >);
+    DataLogger(float sampleTime);
+    void addData(DeviceItem*, std::array < float, 4 >);
     double computeAverage(DeviceItem*, int channel);
     double computeMinimum(DeviceItem*, int channel);
     double computeMaximum(DeviceItem*, int channel);
     void printData(DeviceItem* deviceItem);
-    void setSampleTime(double sampleTime);
+    void setSampleTime(float sampleTime);
 private:
-    double sampleTime;
+    float sampleTime;
     std::ofstream fileStream;
-    std::map < DeviceItem*, std::vector < std::array < double, 4 > > > data;
+    std::map < DeviceItem*, std::vector < std::array < float, 4 > > > data;
     std::map < DeviceItem*, int > dataCounter;
-    std::map < DeviceItem*, std::array < double, 4 > > minimum;
-    std::map < DeviceItem*, std::array < double, 4 > > maximum;
-    std::map < DeviceItem*, std::array < double, 4 > > sum;
-    void updateMinimum(DeviceItem*, std::array < double, 4 >);
-    void updateMaximum(DeviceItem*, std::array < double, 4 >);
-    void updateSum(DeviceItem*, std::array < double, 4 >);    
-    std::array < double, 4 > computeAverage(DeviceItem*);
+    std::map < DeviceItem*, std::array < float, 4 > > minimum;
+    std::map < DeviceItem*, std::array < float, 4 > > maximum;
+    std::map < DeviceItem*, std::array < float, 4 > > sum;
+    void updateMinimum(DeviceItem*, std::array < float, 4 >);
+    void updateMaximum(DeviceItem*, std::array < float, 4 >);
+    void updateSum(DeviceItem*, std::array < float, 4 >);
+    std::array < float, 4 > computeAverage(DeviceItem*);
     void resetData(DeviceItem*);
     std::string modifyDateTime(std::string);
     std::chrono::time_point <std::chrono::system_clock> startTime;

--- a/SMU.h
+++ b/SMU.h
@@ -349,5 +349,6 @@ private:
     std::chrono::time_point <std::chrono::system_clock> startTime;
     std::chrono::time_point <std::chrono::system_clock> lastLog;
     void createLoggingFolder();
+    std::mutex m_logMutex;
 };
 

--- a/SMU.h
+++ b/SMU.h
@@ -348,5 +348,6 @@ private:
     std::string modifyDateTime(std::string);
     std::chrono::time_point <std::chrono::system_clock> startTime;
     std::chrono::time_point <std::chrono::system_clock> lastLog;
+    void createLoggingFolder();
 };
 

--- a/SMU.h
+++ b/SMU.h
@@ -326,6 +326,7 @@ class DataLogger {
 public:
     DataLogger(float sampleTime);
     void addData(DeviceItem*, std::array < float, 4 >);
+    void addBulkData(DeviceItem*, std::vector < std::array < float, 4 > >);
     double computeAverage(DeviceItem*, int channel);
     double computeMinimum(DeviceItem*, int channel);
     double computeMaximum(DeviceItem*, int channel);

--- a/qml/Controller.qml
+++ b/qml/Controller.qml
@@ -69,6 +69,7 @@ Item {
       if (!session.active) {
           session.sampleRate = sampleRate
           session.sampleCount = sampleCount
+          session.sampleTime = sampleTime
           session.start(continuous);
       } else {
           session.cancel();
@@ -78,6 +79,10 @@ Item {
         //console.log("onSampleCountChanged");
         //console.log(sampleCount);
         session.sampleCount = sampleCount;
+  }
+
+  onSampleTimeChanged: {
+      session.sampleTime = sampleTime;
   }
 
 //  Timer {

--- a/qml/Toolbar.qml
+++ b/qml/Toolbar.qml
@@ -64,13 +64,6 @@ ToolbarStyle {
           checked: true
       }
 
-      MenuItem {
-          id: dataLoggingIte
-          text: "Data logging"
-          checkable: true
-          checked: false
-      }
-
       Menu {
         title: "Sample Time"
         MenuItem { exclusiveGroup: timeGroup; checkable: true; checked: controller.sampleTime == 0.01 ? true : false
@@ -81,6 +74,15 @@ ToolbarStyle {
           onTriggered: controller.sampleTime = 1; text: '1 s' }
         MenuItem { exclusiveGroup: timeGroup; checkable: true; checked: controller.sampleTime == 10 ? true : false
           onTriggered: controller.sampleTime = 10; text: '10 s' }
+      }
+
+      MenuItem {
+          id: dataLoggingItem
+          text: "Data logging"
+          checkable: true
+          checked: false
+          enabled: controller.sampleTime == 0.1 || controller.sampleTime == 0.01 ? false : true
+          onTriggered: session.onLoggingChanged()
       }
 
       MenuItem {

--- a/qml/Toolbar.qml
+++ b/qml/Toolbar.qml
@@ -64,6 +64,13 @@ ToolbarStyle {
           checked: true
       }
 
+      MenuItem {
+          id: dataLoggingIte
+          text: "Data logging"
+          checkable: true
+          checked: false
+      }
+
       Menu {
         title: "Sample Time"
         MenuItem { exclusiveGroup: timeGroup; checkable: true; checked: controller.sampleTime == 0.01 ? true : false


### PR DESCRIPTION
Added data logging functionality.

One can now log the samples generated by Pixelpulse. 

    How does it work? 
You can log the generated samples on a sample time of 1 or 10 seconds. The sample time is chosen from Pixelpulse's menu. If one of this sample times is checked, the data logging label becomes checkable. If you want to log the next session, you must check data logging from the menu. Every 1 or 10 seconds (depending on the sample time), the samples are logged.

    How are the samples logged?
For each interval of time, the logger computes the minimum, maximum and average for the voltage and current from each device, on every channel. It also logs the device to which each data corresponds and the moment of time when the log was done (relative to the starting time). The file also includes on it's first line, the description for each column. 
The file name is PP_Log_{datetime}.csv, where {datetime} is the date and the time when the file was generated (when the logged session started).

    Where are these files located?
In Pixelpulse's folder, it will be generated a folder having the name ,,logging". It will contain all generated logging files.

For the moment, there is a small delay when having two or more devices connected and logging the data. This will be fixed soon.