### PR TITLE
Data logging fix

### DIFF
--- a/SMU.cpp
+++ b/SMU.cpp
@@ -320,8 +320,7 @@ void SessionItem::getSamples()
             }
 
             if (m_logging) {
-                std::thread t1([=] {this->m_data_logger->addBulkData(dev, rxbuf);});
-                t1.detach();
+                m_data_logger->addBulkData(dev, rxbuf);
             }
             i++;
         }
@@ -662,7 +661,7 @@ void BufferChanger::changeBuffer(){
     this->thread()->quit();
 }
 
-DataLogger::DataLogger(float sampleTime)
+DataLogger::DataLogger(float sampleTime, QObject* parent) : QObject(parent)
 {
     //if created by a valid session (1s or 10s sample time), create the log file
     if (sampleTime != -1
@@ -737,7 +736,6 @@ void DataLogger::resetData(DeviceItem* deviceItem)
 
 void DataLogger::addData(DeviceItem * deviceItem, std::array<float, 4> samples)
 {
-    m_logMutex.lock();
     if (dataCounter[deviceItem] == 0) {
         resetData(deviceItem);
     }
@@ -756,17 +754,18 @@ void DataLogger::addData(DeviceItem * deviceItem, std::array<float, 4> samples)
             resetData(pair.first);
         }
     }
-    m_logMutex.unlock();
 }
 
 void DataLogger::addBulkData(DeviceItem* deviceItem, std::vector<std::array<float, 4> > buff)
 {
-    for (auto sample : buff)
-        addData(deviceItem, sample);
+    QtConcurrent::run(&m_threadPool, [this, deviceItem, buff] {
+        doAddBulkData(deviceItem, buff);
+    });
 }
 
 void DataLogger::printData(DeviceItem* deviceItem)
 {
+    m_logMutex.lock();
     string deviceSerial = deviceItem->m_device->m_serial;
     deviceSerial = deviceSerial.substr(deviceSerial.size() - 5, 5);
     std::chrono::duration < double > timeDiff = std::chrono::system_clock::now() - startTime;
@@ -778,6 +777,7 @@ void DataLogger::printData(DeviceItem* deviceItem)
                      << maximum[deviceItem][0] << "," << maximum[deviceItem][1] << "," << maximum[deviceItem][2] << "," << maximum[deviceItem][3] << ","
                      << average[0] << "," << average[1] << "," << average[2] << "," << average[3] << '\n';
     fileStream.flush();
+    m_logMutex.unlock();
 }
 
 void DataLogger::setSampleTime(float sampleTime)
@@ -789,5 +789,12 @@ void DataLogger::createLoggingFolder()
 {
     if (!QDir("logging").exists()) {
         QDir().mkdir("logging");
+    }
+}
+
+void DataLogger::doAddBulkData(DeviceItem* deviceItem, std::vector<std::array<float, 4>> buff)
+{
+    for (auto sample : buff) {
+        addData(deviceItem, sample);
     }
 }

--- a/SMU.h
+++ b/SMU.h
@@ -9,6 +9,8 @@
 #include <QTime>
 #include <cmath>
 #include <fstream>
+#include <QThreadPool>
+#include <QtConcurrent/QtConcurrent>
 
 class SessionItem;
 class DeviceItem;
@@ -322,9 +324,10 @@ protected slots:
 
 void registerTypes();
 
-class DataLogger {
+class DataLogger: public QObject {
+    Q_OBJECT
 public:
-    DataLogger(float sampleTime);
+    DataLogger(float sampleTime, QObject* parent = nullptr);
     void addData(DeviceItem*, std::array < float, 4 >);
     void addBulkData(DeviceItem*, std::vector < std::array < float, 4 > >);
     double computeAverage(DeviceItem*, int channel);
@@ -350,5 +353,8 @@ private:
     std::chrono::time_point <std::chrono::system_clock> lastLog;
     void createLoggingFolder();
     std::mutex m_logMutex;
+    int m_threadsNumber = 5;
+    QThreadPool m_threadPool;
+    void doAddBulkData(DeviceItem*, std::vector < std::array < float, 4 > >);
 };
 


### PR DESCRIPTION
Improved the data logging mechanism. Before this update, the data logger was creating a new thread for each logging procedure, making it to run slower. I have implemented a thread pool in order to avoid this situation. 

This branch is rebased with the [release-build branch](https://github.com/analogdevicesinc/Pixelpulse2/tree/build-fixes) (in order to use the CMake build) so that #242 should be merged into master first. 