### PR TITLE
SMU.cpp: change data logger write path.

### DIFF
--- a/SMU.cpp
+++ b/SMU.cpp
@@ -666,7 +666,8 @@ DataLogger::DataLogger(float sampleTime)
         auto current_time = std::chrono::system_clock::now();
         std::time_t time = std::chrono::system_clock::to_time_t(current_time);
         createLoggingFolder();
-        string timeString = "logging/PP_Log_";
+        QString directory = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
+        string timeString = directory.toStdString() + "/logging/PP_Log_";
         timeString.append(modifyDateTime(std::ctime(&time)));
         timeString.append(".csv");
         fileStream.open(timeString.c_str(), std::ios::out);
@@ -782,7 +783,8 @@ void DataLogger::setSampleTime(float sampleTime)
 
 void DataLogger::createLoggingFolder()
 {
-    if (!QDir("logging").exists()) {
-        QDir().mkdir("logging");
+    QString directory = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
+    if (!QDir(directory + "/logging").exists()) {
+        QDir().mkpath(directory + "/logging");
     }
 }

--- a/main.cpp
+++ b/main.cpp
@@ -14,7 +14,7 @@
 int main(int argc, char *argv[])
 {
     // Prevent config being written to ~/.config/Unknown Organization/pixelpulse2.conf
-    QCoreApplication::setOrganizationName("Pixelpulse2");
+    QCoreApplication::setOrganizationName("ADI");
     QCoreApplication::setApplicationName("Pixelpulse2");
 
     QLocale::setDefault(QLocale(QLocale::English, QLocale::UnitedStates));


### PR DESCRIPTION
The logged data was stored in the logging folder from Pixelpulse's default installation folder.
On most Windows machines, the installation folder was in C:/Program Files/Analog Devices, requiring admin privileges to write files here.
To avoid the admin permission issue, we have changed the logging folder to the AppData folder (C:\Users\<User>\AppData\Roaming\Pixelpulse2 and their equivalents for Linux and MacOS; more details about Qt's QStandardPaths::AppDataLocation [here](https://doc.qt.io/qt-5/qstandardpaths.html)).

Signed-off-by: Cristi Iacob <cristian.iacob@analog.com>